### PR TITLE
Fix #2: PHP 4 style constructors are deprecated

### DIFF
--- a/class.php
+++ b/class.php
@@ -64,7 +64,7 @@ class Student {
                                          "set_fac", "get_fac", "print", "set_grades",
                                          "get_grades", "get_grade", "make_unusable", "to_string");
 
-    function Student() {
+    function __construct() {
         $this->valid = true;
         $this->annual_grade = 0.0;
          Student::$num_instances += 1;
@@ -153,7 +153,7 @@ class Faculty {
     var $university_name;
     var $students = array();
 
-    function Faculty($n, $cty, $ctry, $uname) {
+    function __construct($n, $cty, $ctry, $uname) {
         $this->name = $n;
         $this->city = $cty;
         $this->country = $ctry;


### PR DESCRIPTION
Since the old stlye constructors are deprecated as of PHP 7.0.0, and
__construct() is already fully supported as of PHP 5.0.0, we change the
names of the constructors.