### PR TITLE
parse_str() without 2nd argument is deprecated

### DIFF
--- a/standard_calls.php
+++ b/standard_calls.php
@@ -104,7 +104,7 @@ function run_standard_calls($STANDARD_CALL_IT) {
 		array_walk($test_array, 'do_nothing');
 		krsort($test_array);
 		ksort($test_array);
-		parse_str($var1);
+		parse_str($var1, $dummy);
 		end($test_array);
 		reset($test_array);
 		array_shift($test_array);


### PR DESCRIPTION
As of PHP 7.2.0, calling parse_str() with only one parameter is
deprecated, and as of PHP 8.0.0, this even errors.  To avoid optimizing
error paths, we add a dummy argument, which otherwise does not affect
the execution.