### PR TITLE
Fix initialization with PHP 8.1

### DIFF
--- a/init.php
+++ b/init.php
@@ -149,6 +149,7 @@ function initDB() {
     $conn->close();
 }
 
+mysqli_report(MYSQLI_REPORT_OFF);
 initDB();
 printExistingDB();
 ?>


### PR DESCRIPTION
As of PHP 8.1.0, the default mysqli error mode has been changed to
exception mode[1].  That causes `$conn->select_db(DB_NAME)` to fail
with an uncaught exception, preventing the database to be properly
initialized.

This pull request fixes this in the least intrusive way, namely by
manually setting the error mode back to silent.

[1] <https://wiki.php.net/rfc/mysqli_default_errmode>

---

Other than this, I have not detected other issues with PHP 8.1 so far.